### PR TITLE
Fix bug in getting "content-type" header from `fetch` response

### DIFF
--- a/handler.js
+++ b/handler.js
@@ -21,7 +21,7 @@ module.exports.corsProxy = async (event, context, fetchArg) => {
       headers: {
         "Access-Control-Allow-Origin": allowOriginFilter(origin, allowedOrigins), // Required for CORS support to work
         "Access-Control-Allow-Credentials": true, // Required for cookies, authorization headers with HTTPS
-        "content-type": response.headers['content-type']
+        "content-type": response.headers.get('content-type'),
       }
     };
   } catch(err) {

--- a/spec/corsProxy.spec.js
+++ b/spec/corsProxy.spec.js
@@ -26,7 +26,11 @@ describe('corsProxy', () => {
       text: function() {
         return data;
       },
-      headers,
+      headers: {
+        get: function(header) {
+          return headers[header];
+        }
+      }
     };
     fetchSpy = jasmine.createSpy('fetch')
         .and.returnValue(Promise.resolve(response));


### PR DESCRIPTION
The `response` from `fetch` is different from the `response` returned by `axios`.

The test fake that was dependency injected into the handler was behaving like an `axios` response instead of a `fetch` response object, so the bug was hidden until it was actually deployed and run with a real `fetch`.