### PR TITLE
Add Lambda test event for arbitrary 4th level subdomain and add example to handler.js comment

### DIFF
--- a/handler.js
+++ b/handler.js
@@ -54,8 +54,12 @@
 // - Include a trailing comma to make editing easier.  See "Trailing commas":
 //       https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Trailing_commas
 const ALLOWED_ORIGINS_REGEXPS = [
-    // Matches "library.nyu.edu" and any its subdomains.
-    // Example matches: https://dev.library.nyu.edu, http://library.nyu.edu
+    // Matches "library.nyu.edu" and any 4th level subdomains, either HTTP or
+    // HTTPS.
+    // Example matches:
+    //    • https://dev.library.nyu.edu
+    //    • http://library.nyu.edu
+    //    • https://arbitrary-4th-level-subdomain.library.nyu.edu
     'https?://(?:[^.]+\\.)?library.nyu.edu',
 ];
 

--- a/lambda-test-events/README.md
+++ b/lambda-test-events/README.md
@@ -2,6 +2,10 @@
 
 These test events have been manually deployed to Lambda:
 
+* Name: "Any future 4th level *.library.nyu.edu subdomain"
+  * Source: _[arbitrary-4th-level-subdomain.library.nyu.edu](arbitrary-4th-level-subdomain.library.nyu.edu.json)_
+  * Expected result: HTTP 200 response with RSS data in the body and the expected
+    CORS HTTP headers which allow access to https://arbitrary-4th-level-subdomain.library.nyu.edu
 * Name: "Blank resource URL"
   * Source: _[blank-resource-url.json](blank-resource-url.json)_
   * Expected result: HTTP 422 error response with error details in the body.

--- a/lambda-test-events/arbitrary-4th-level-subdomain.library.nyu.edu.json
+++ b/lambda-test-events/arbitrary-4th-level-subdomain.library.nyu.edu.json
@@ -1,0 +1,8 @@
+{
+    "queryStringParameters": {
+        "url": "https%3A%2F%2Fguides.nyu.edu%2Frss%2Fblog.php"
+    },
+    "headers": {
+        "origin": "https://arbitrary-4th-level-subdomain.library.nyu.edu"
+    }
+}


### PR DESCRIPTION
Add Lambda test event for "https://arbitrary-4th-level-subdomain.library.nyu.edu" and expand `ALLOWED_ORIGINS_REGEXPS` comment.